### PR TITLE
Update to save as string

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,13 +1,13 @@
-import { Prisma, PrismaClient } from '@prisma/client';
+import { Prisma, PrismaClient } from "@prisma/client";
 
-const prisma = new PrismaClient()
+const prisma = new PrismaClient();
 
 async function run() {
   await prisma.entry.create({
     data: {
-      value: new Prisma.Decimal('93431006234343600001')
-    }
-  })
+      value: "93431006234343600001",
+    },
+  });
 }
 
-run()
+run();

--- a/index.ts
+++ b/index.ts
@@ -3,11 +3,22 @@ import { Prisma, PrismaClient } from "@prisma/client";
 const prisma = new PrismaClient();
 
 async function run() {
-  await prisma.entry.create({
+  const t = await prisma.entry.findFirst();
+
+  await prisma.entry.update({
+    where: {
+      id: 1,
+    },
     data: {
-      value: "93431006234343600001",
+      value: 123861532518063870000,
     },
   });
+
+  // await prisma.entry.create({
+  //   data: {
+  //     value: 93431006234343600001111111,
+  //   },
+  // });
 }
 
 run();

--- a/prisma/migrations/20220506163924_float/migration.sql
+++ b/prisma/migrations/20220506163924_float/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to alter the column `value` on the `Entry` table. The data in that column could be lost. The data in that column will be cast from `Decimal(65,30)` to `DoublePrecision`.
+
+*/
+-- AlterTable
+ALTER TABLE "Entry" ALTER COLUMN "value" SET DATA TYPE DOUBLE PRECISION;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -11,6 +11,6 @@ datasource db {
 }
 
 model Entry {
-  id    Int     @id @default(autoincrement())
-  value Decimal
+  id    Int   @id @default(autoincrement())
+  value Float
 }


### PR DESCRIPTION
Datatype can remain the same, but prisma enables sending as string